### PR TITLE
Potential fix for code scanning alert no. 4: Clear-text logging of sensitive information

### DIFF
--- a/migration.py
+++ b/migration.py
@@ -155,9 +155,9 @@ def run_migration():
         # Check if password columns still exist
         password_columns = [col for col in final_columns if 'password' in col.lower()]
         if password_columns:
-            logger.error(f"❌ Password columns still exist: {password_columns}")
+            logger.error("❌ Password-related columns still exist in the database schema.")
         else:
-            logger.info("✅ All password columns successfully removed")
+            logger.info("✅ All password-related columns successfully removed")
         
         logger.info("🎉 Migration completed successfully!")
         


### PR DESCRIPTION
Potential fix for [https://github.com/sispt/grade-phoenix-bot/security/code-scanning/4](https://github.com/sispt/grade-phoenix-bot/security/code-scanning/4)

To fix the issue, we should avoid logging the `password_columns` list directly. Instead, we can log a generic message indicating that password-related columns still exist without revealing their names. This approach ensures that sensitive schema information is not exposed in the logs while maintaining the functionality of the migration script.

**Steps to implement the fix:**
1. Replace the logging statement on line 158 with a generic message that does not include the `password_columns` list.
2. Ensure that the rest of the script remains unchanged to preserve its functionality.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
